### PR TITLE
add tools target, currently used to install ginkgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,7 @@ clean:
 		*-windows-amd64 \
 		*.sha256 \
 		$(NULL)
+
+.PHONY: tools
+tools: ## Install tools to ${GOPATH}/bin
+	go get -u github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
I've added a build target named tools which will install ginkgo to ${GOPATH}/bin