### PR TITLE
teams + secondary view refactored

### DIFF
--- a/cmd/pdcli/alerts/cmd.go
+++ b/cmd/pdcli/alerts/cmd.go
@@ -98,6 +98,10 @@ func alertsHandler(cmd *cobra.Command, args []string) error {
 	// Fetch the currently logged in user's ID.
 	user, err := client.GetCurrentUser(pdApi.GetCurrentUserOptions{})
 
+	if err != nil {
+		return err
+	}
+
 	// UI internals
 	tui.Client = client
 	tui.Username = user.Name
@@ -156,6 +160,7 @@ func alertsHandler(cmd *cobra.Command, args []string) error {
 		}
 
 		teamID := cfg.TeamID
+		tui.AssginedTo = cfg.Team
 
 		if teamID == "" {
 			return fmt.Errorf("no team selected, please run 'pdcli teams' to set a team")
@@ -168,9 +173,13 @@ func alertsHandler(cmd *cobra.Command, args []string) error {
 		// Fetch incidents assigned to silent test
 		incidentOpts.UserIDs = append(users, constants.SilentTest)
 
+		tui.AssginedTo = "Silent Test"
+
 	case "self":
 		// Fetch incidents only assigned to self
 		incidentOpts.UserIDs = append(users, user.ID)
+
+		tui.AssginedTo = user.Name
 	}
 
 	// Check urgency
@@ -214,7 +223,6 @@ func alertsHandler(cmd *cobra.Command, args []string) error {
 		alerts = append(alerts, incidentAlerts...)
 	}
 
-	tui.AssginedTo = options.assignment
 	tui.FetchedAlerts = strconv.Itoa(len(alerts))
 
 	// Setup TUI

--- a/cmd/pdcli/login/cmd.go
+++ b/cmd/pdcli/login/cmd.go
@@ -120,13 +120,14 @@ func loginHandler(cmd *cobra.Command, args []string) error {
 
 	// Check if user has selected a team
 	if cfg.TeamID == "" {
-		teamdID, err := teams.SelectTeam(pdClient, os.Stdin)
+		teamdID, name, err := teams.SelectTeam(pdClient, os.Stdin)
 
 		if err != nil {
 			return err
 		}
 
 		cfg.TeamID = teamdID
+		cfg.Team = name
 	}
 
 	// Save the Team ID to the config file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ import (
 type Config struct {
 	ApiKey string `json:"api_key,omitempty"`
 	TeamID string `json:"team_id,omitempty"`
+	Team   string `json:"team,omitempty"`
 }
 
 // Find returns the pdcli configuration filepath.

--- a/tests/teams_test.go
+++ b/tests/teams_test.go
@@ -32,13 +32,14 @@ var _ = Describe("select team", func() {
 			userResponse := &pdApi.User{
 				Name: "my-user",
 				Teams: []pdApi.Team{
-					{Name: "my-team-a", APIObject: pdApi.APIObject{ID: "ABCD123"}},
-					{Name: "my-team-b", APIObject: pdApi.APIObject{ID: "EFGH456"}},
-					{Name: "my-team-c", APIObject: pdApi.APIObject{ID: "IJKL789"}},
+					{APIObject: pdApi.APIObject{ID: "ABCD123", Summary: "my-team-a"}},
+					{APIObject: pdApi.APIObject{ID: "EFGH456", Summary: "my-team-b"}},
+					{APIObject: pdApi.APIObject{ID: "IJKL789", Summary: "my-team-c"}},
 				},
 			}
 
-			expectedResult := "EFGH456"
+			expectedTeamID := "EFGH456"
+			expectedTeamName := "my-team-b"
 
 			mockClient.EXPECT().GetCurrentUser(gomock.Any()).Return(userResponse, nil).Times(1)
 
@@ -46,11 +47,13 @@ var _ = Describe("select team", func() {
 
 			stdin.Write([]byte("2\n"))
 
-			result, err := teams.SelectTeam(mockClient, &stdin)
+			teamID, teamName, err := teams.SelectTeam(mockClient, &stdin)
 
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(result).To(Equal(expectedResult))
+			Expect(teamID).To(Equal(expectedTeamID))
+
+			Expect(teamName).To(Equal(expectedTeamName))
 		})
 	})
 
@@ -60,9 +63,9 @@ var _ = Describe("select team", func() {
 			userResponse := &pdApi.User{
 				Name: "my-user",
 				Teams: []pdApi.Team{
-					{Name: "my-team-a", APIObject: pdApi.APIObject{ID: "ABCD123"}},
-					{Name: "my-team-b", APIObject: pdApi.APIObject{ID: "EFGH456"}},
-					{Name: "my-team-c", APIObject: pdApi.APIObject{ID: "IJKL789"}},
+					{APIObject: pdApi.APIObject{ID: "ABCD123", Summary: "my-team-a"}},
+					{APIObject: pdApi.APIObject{ID: "EFGH456", Summary: "my-team-b"}},
+					{APIObject: pdApi.APIObject{ID: "IJKL789", Summary: "my-team-c"}},
 				},
 			}
 
@@ -72,11 +75,13 @@ var _ = Describe("select team", func() {
 
 			stdin.Write([]byte("X\n"))
 
-			result, err := teams.SelectTeam(mockClient, &stdin)
+			teamID, teamName, err := teams.SelectTeam(mockClient, &stdin)
 
 			Expect(err).To(HaveOccurred())
 
-			Expect(result).To(BeEmpty())
+			Expect(teamID).To(BeEmpty())
+
+			Expect(teamName).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
1. Refactored teams command to save the selected team name to config file.
2. The secondary view UI in alerts will now show the assigned-to string appropriately.