### PR TITLE
Removing user Dominic Finn from maintainers in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ $ mockgen -source=foo.go -destination=mock/foo_mock.go
 ```
 
 ## Maintainers
-- Dominic Finn (dofinn@redhat.com)
 - Mitali Bhalla (mbhalla@redhat.com)
 - Supreeth Basabattini (sbasabat@redhat.com)
 - Tomas Dabašinskas (todabasi@redhat.com)


### PR DESCRIPTION
This PR serves the purpose of removing user Dominic Finn as a maintainer in the Readme's section of maintainers as he has left Red Hat.