### PR TITLE
Removing apprentices from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,6 @@ reviewers:
 - T0MASD
 - supreeth7
 - MitaliBhalla
-- Deepanshu276
-- Dee-6777
-- devppratik
 approvers:
 - T0MASD
 - supreeth7


### PR DESCRIPTION
This PR serves the purpose of removing apprentices from OWNERS (i.e their removal as reviewers) as the purpose of checking their readiness for creating Pull requests has been completed. They are still new to the project and our entire system, hence it will not be best suited to keep them as reviewers now, we can definitely come back to this again and happily add them in future as they progress and develop more.