### PR TITLE
OSD-15172: Added coverage command to MakeFile. Updated test & lint commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GOOS?=linux
 GOARCH?=amd64
 GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOFLAGS=
 GOPATH := $(shell go env GOPATH)
+HOME=$(shell mktemp -d)
+GOLANGCI_LINT_VERSION=v1.51.2
 
 # Ensure go modules are enabled:
 export GO111MODULE=on
@@ -34,10 +36,28 @@ tools:
 test:
 	go test ./... -covermode=atomic -coverpkg=./... -v
 
+test-cover:
+	go test -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+
+.PHONY: coverage-html
+cover-html:
+	go tool cover -html=coverage.out
+
+.PHONY:coverage
+coverage:test-cover
+	@{ \
+	set -e ;\
+	REQ_COV=15.5 ;\
+	TEST_COV=$$(go tool cover -func coverage.out | grep -F total | awk '{print substr($$3, 1, length($$3)-1)}' ) ;\
+	if (( $$(echo "$$REQ_COV > $$TEST_COV" |bc -l) )); then echo "Error: Code Coverage is less"; exit 1 ;\
+	else echo "Code Coverage Test Passed"; exit 0; fi ;\
+	}
+	@rm -rf coverage.out
+
 # Installed using instructions from: https://golangci-lint.run/usage/install/#linux-and-windows
 getlint:
 	@mkdir -p $(GOPATH)/bin
-	@ls $(GOPATH)/bin/golangci-lint 1>/dev/null || (echo "Installing golangci-lint..." && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.42.0)
+	@ls $(GOPATH)/bin/golangci-lint 1>/dev/null || (echo "Installing golangci-lint..." && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION))
 
 .PHONY: lint
 lint: getlint

--- a/OWNERS
+++ b/OWNERS
@@ -10,5 +10,3 @@ maintainers:
 - supreeth7
 - MitaliBhalla
 - T0MASD
-- Deepanshu276
-- Dee-6777


### PR DESCRIPTION
This PR aims to update the CI Pipeline for kite.

1. **test command** - updated with coverprofile flag to output the total coverage into a file
2. **lint command** - changed golangci-lint installation method
3. **coverage command** - uses the coverage file from test to get the total test coverage. The min desired code coverage overall is set at 15.5%. If code coverage is less than that, the test would fail.

