### PR TITLE
OSD-15291: Excluded SilentTest Alerts when kite --assigned-to team is run

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -37,6 +37,12 @@ const (
 	// PagerDuty IDs
 	TeamID     = "PASPK4G"
 	SilentTest = "P8QS6CC"
+	NobodySREP = "P53J4TK"
+
+	// Escalation Policy IDs
+	SilentTestEscalationPolicyID         = "PCGXUDY"
+	CADSilentTestEscalationPolicyID      = "PQXIBX3"
+	CADSilentTestStageEscalationPolicyID = "PBWX63A"
 
 	// PagerDuty Incident Statuses
 	StatusTriggered    = "triggered"


### PR DESCRIPTION
### **Before the change :** 
When a user runs **kite alerts --assigned-to team**, they were shown all alerts assigned to their team.
![image](https://user-images.githubusercontent.com/56730201/222873716-952adc03-55bf-4377-bebd-bc4c097f15b9.png)

This included the alerts also assigned to Silent Test when the **kite alerts --assigned-to silentTest** command is run
![image](https://user-images.githubusercontent.com/56730201/222874652-5cd737da-3770-4547-b2cd-f55b63509383.png)

### **After the change :**
The kite alerts --assigned-to team removes every Silent Test alert from the list

![image](https://user-images.githubusercontent.com/56730201/222873684-b9ba8eb3-9c5b-403e-933d-6addbbd70aca.png)
