### PR TITLE
OSD-9083: Preferred terminal sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This will list all the alerts belonging to that incident.
 
 ### Options
 ```
---assigned-to          Filter alerts based on user or team (default "self")
+--assigned-to          Filter alerts based on user or team (default "self") 
 --columns              Specify which columns to display separated by commas without any space in between 
                        (default "incident.id,alert,cluster.name,cluster.id,status,severity")
 ```
@@ -152,6 +152,14 @@ By default, all the escalations and Oncalls are displayed for team **Platform-SR
 | Your Next Oncall Schedule                                      | `N`                           | Displays your Oncall schedule.                                        |
 | Go back                                                        | `Esc`                         | Navigate to the previous page.                                         |
 | Quit                                                           | `Q` / `q`                     | Exit the application.                                                  |
+
+## Terminal
+To Select a preferred terminal emulator, use the command:
+
+```
+kite terminal
+```
+This will list all the terminal emulator emulators supported by the system and will prompt the user to select an emulator for kite.
 ## Running Tests
 The test suite uses the [Ginkgo](https://onsi.github.io/ginkgo/) to run comprehensive tests using Behavior-Driven Development.<br>
 The mocking framework used for testing is [gomock](https://github.com/golang/mock).

--- a/cmd/kite/alerts/cmd.go
+++ b/cmd/kite/alerts/cmd.go
@@ -68,7 +68,6 @@ func init() {
 
 // alertsHandler is the main alerts command handler.
 func alertsHandler(cmd *cobra.Command, args []string) error {
-
 	var (
 		// Internals
 		incidentAlerts []pdcli.Alert
@@ -86,9 +85,6 @@ func alertsHandler(cmd *cobra.Command, args []string) error {
 	// Setup TUI
 	tui.Init()
 	utils.InfoLogger.Print("Initialized terminal UI")
-
-	// Determine terminal emulator for cluster login
-	utils.InitTerminalEmulator()
 
 	if utils.Emulator != "" {
 		utils.InfoLogger.Printf("Terminal emulator for cluster login set to: %s", utils.Emulator)

--- a/cmd/kite/main.go
+++ b/cmd/kite/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/kite/root.go
+++ b/cmd/kite/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,6 +20,8 @@ import (
 	"github.com/openshift/pagerduty-short-circuiter/cmd/kite/login"
 	"github.com/openshift/pagerduty-short-circuiter/cmd/kite/oncall"
 	"github.com/openshift/pagerduty-short-circuiter/cmd/kite/teams"
+	"github.com/openshift/pagerduty-short-circuiter/cmd/kite/terminal"
+
 	"github.com/spf13/cobra"
 )
 
@@ -42,6 +44,7 @@ func init() {
 	rootCmd.AddCommand(alerts.Cmd)
 	rootCmd.AddCommand(oncall.Cmd)
 	rootCmd.AddCommand(teams.Cmd)
+	rootCmd.AddCommand(terminal.Cmd)
 
 	//Do not provide the default completion command
 	rootCmd.CompletionOptions.DisableDefaultCmd = true

--- a/cmd/kite/terminal/cmd.go
+++ b/cmd/kite/terminal/cmd.go
@@ -1,0 +1,63 @@
+/*
+Copyright © 2021 Red Hat, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package terminal
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/pagerduty-short-circuiter/pkg/config"
+	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "terminal",
+	Short: "This command lets the user choose their preferred terminal emulator .",
+	Args:  cobra.NoArgs,
+	RunE:  selectTerminal,
+}
+
+func selectTerminal(cmd *cobra.Command, args []string) error {
+
+	cfg, err := config.Load()
+	if err != nil {
+		err = fmt.Errorf("configuration file not found, run the 'kite login' command")
+		return err
+
+	}
+
+	// List all the available terminal emulators and prompt the user to select one.
+	selectedTerminal := utils.InitTerminalEmulator()
+
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	if selectedTerminal == "" {
+		os.Exit(1)
+	}
+	// Update the terminal configuration value in the config file.
+	cfg.Terminal = selectedTerminal
+
+	err = config.Save(cfg)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Emulator selected successfully")
+	return nil
+
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -53,7 +53,6 @@ func (pd *PDClient) Connect() (client *PDClient, err error) {
 
 		// Load the configuration file
 		pd.cfg, err = config.Load()
-
 		if err != nil {
 			err = fmt.Errorf("configuration file not found, run the 'kite login' command")
 			return nil, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,9 +30,10 @@ import (
 
 // Configuration struct to store user configuration.
 type Config struct {
-	ApiKey string `json:"api_key,omitempty"`
-	TeamID string `json:"team_id,omitempty"`
-	Team   string `json:"team,omitempty"`
+	ApiKey   string `json:"api_key,omitempty"`
+	TeamID   string `json:"team_id,omitempty"`
+	Team     string `json:"team,omitempty"`
+	Terminal string `json:"terminal,omitempty"`
 }
 
 // Find returns the pdcli configuration filepath.

--- a/pkg/terminal/terminalui.go
+++ b/pkg/terminal/terminalui.go
@@ -1,0 +1,70 @@
+package terminal
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type EUI struct {
+	app  *tview.Application
+	list *tview.List
+}
+
+var (
+	selectedTerminal string
+	selected         bool
+)
+
+func (eui *EUI) UiEmulator(terminals []string) string {
+	eui.app = tview.NewApplication()
+
+	eui.list = tview.NewList().ShowSecondaryText(false)
+
+	// Add the available terminal emulators to the list.
+	for i, t := range terminals {
+		func(t string) {
+			eui.list.AddItem(fmt.Sprintf("%d. %s", i+1, t), "", 0, func() {
+				selectedTerminal = t
+				selected = true
+				eui.app.Stop()
+			})
+		}(t)
+	}
+
+	eui.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Rune() == 'q' || event.Rune() == 'Q' {
+
+			selected = false
+			eui.app.Stop()
+			return nil
+		}
+		return event
+	})
+
+	// Set the list as the root of the application and focus on it.
+	eui.app.SetRoot(eui.list, true).SetFocus(eui.list)
+
+	// Add a footer with a quit message.
+	footer := tview.NewTextView().SetText("Q [Quit]")
+	eui.app.SetRoot(
+		tview.NewFlex().
+			SetDirection(tview.FlexRow).
+			AddItem(eui.list, 0, 1, true).
+			AddItem(footer, 1, 0, false),
+		true,
+	)
+
+	// Run the application and wait for the user to make a selection.
+	if err := eui.app.Run(); err != nil {
+		fmt.Println("Error:", err)
+	}
+
+	if selected {
+		return selectedTerminal
+	}
+
+	// Return an empty string if the user quits.
+	return ""
+}

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/gdamore/tcell/v2"
+
 	pdcli "github.com/openshift/pagerduty-short-circuiter/pkg/pdcli/alerts"
 	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
 )

--- a/pkg/utils/emulator.go
+++ b/pkg/utils/emulator.go
@@ -5,16 +5,20 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/openshift/pagerduty-short-circuiter/pkg/constants"
+	"github.com/openshift/pagerduty-short-circuiter/pkg/terminal"
 )
 
 // Installed terminal emulator
 var Emulator string
 
 // InitTerminalEmulator tries to set a terminal emulator by trying some known terminal emulators.
-func InitTerminalEmulator() {
+func InitTerminalEmulator() string {
+	var (
+		eui terminal.EUI
+	)
+
 	emulators := []string{
 		"gnome-terminal",
 		"x-terminal-emulator",
@@ -34,17 +38,18 @@ func InitTerminalEmulator() {
 		"hyper",
 	}
 
+	terminals := []string{}
 	for _, t := range emulators {
-		cmd := exec.Command("command", "-v", t)
-		output, _ := cmd.CombinedOutput()
-		cmd.ProcessState.Exited()
-		term := string(output)
-		term = strings.TrimSpace(term)
-
-		if term != "" {
-			Emulator = term
+		_, err := exec.LookPath(t)
+		if err == nil {
+			terminals = append(terminals, t)
 		}
+
 	}
+
+	Emulator = eui.UiEmulator(terminals)
+
+	return Emulator
 }
 
 // ClusterLoginShell spawns an instance of ocm-container in the same shell.


### PR DESCRIPTION
Added the new sub command called terminal using which user can select their preferred terminal emulator from their local system. Users needs to run kite terminal which will list down all the installed terminal emulators of their system and they can select their desired emulator.
Workflow : 
Login into the kite and enter you credential and select team then
run the kite terminal sub command which will give the list of the terminal emulator
![terminal](https://user-images.githubusercontent.com/56041032/224244749-979151d8-8f39-47a4-b598-5ea417c5fadd.png)


