### PR TITLE
OSD-9102 : assigned to column added in incidents table

### DIFF
--- a/pkg/ui/seeders.go
+++ b/pkg/ui/seeders.go
@@ -52,7 +52,8 @@ func (tui *TUI) SeedAckIncidentsUI() {
 	}
 
 	for _, i := range incidents {
-		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary, i.Assignments[0].Assignee.Summary}
+		I := i.Assignments[0]
+		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary, I.Assignee.Summary}
 		ackIncidents = append(ackIncidents, incident)
 	}
 

--- a/pkg/ui/seeders.go
+++ b/pkg/ui/seeders.go
@@ -52,7 +52,7 @@ func (tui *TUI) SeedAckIncidentsUI() {
 	}
 
 	for _, i := range incidents {
-		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary}
+		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary, i.Assignments[0].Assignee.Summary}
 		ackIncidents = append(ackIncidents, incident)
 	}
 

--- a/pkg/ui/seeders.go
+++ b/pkg/ui/seeders.go
@@ -52,7 +52,7 @@ func (tui *TUI) SeedAckIncidentsUI() {
 	}
 
 	for _, i := range incidents {
-		// Added columns 'Id', 'Title', 'Status', 'Service', 'Assigned To' to triggered incidents table
+		// Added columns 'Id', 'Title', 'Status', 'Service', 'Assigned To' to acknlowedged incidents table
 		assignment := i.Assignments[0]
 		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary, assignment.Assignee.Summary}
 		ackIncidents = append(ackIncidents, incident)

--- a/pkg/ui/seeders.go
+++ b/pkg/ui/seeders.go
@@ -52,8 +52,9 @@ func (tui *TUI) SeedAckIncidentsUI() {
 	}
 
 	for _, i := range incidents {
-		I := i.Assignments[0]
-		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary, I.Assignee.Summary}
+		// Added columns 'Id', 'Title', 'Status', 'Service', 'Assigned To' to triggered incidents table
+		assignment := i.Assignments[0]
+		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary, assignment.Assignee.Summary}
 		ackIncidents = append(ackIncidents, incident)
 	}
 
@@ -84,7 +85,9 @@ func (tui *TUI) SeedIncidentsUI() {
 	}
 
 	for _, i := range incidents {
-		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary}
+		// Added columns 'Id', 'Title', 'Status', 'Service', 'Assigned To' to triggered incidents table
+		assignment := i.Assignments[0]
+		incident := []string{i.Id, i.Title, i.Urgency, i.Status, i.Service.Summary, assignment.Assignee.Summary}
 		incidentsData = append(incidentsData, incident)
 	}
 

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -67,7 +67,7 @@ func (tui *TUI) InitAlertsUI(alerts []pdcli.Alert, tableTitle string, pageTitle 
 // InitIncidentsUI initializes TUI table component.
 // It adds the returned table as a new TUI page view.
 func (tui *TUI) InitIncidentsUI(incidents [][]string, tableTitle string, pageTitle string, isSelectable bool) {
-	incidentHeaders := []string{"INCIDENT ID", "NAME", "SEVERITY", "STATUS", "SERVICE"}
+	incidentHeaders := []string{"INCIDENT ID", "NAME", "SEVERITY", "STATUS", "SERVICE", "ASSIGNED TO"}
 
 	if isSelectable {
 		tui.IncidentsTable = tui.InitTable(incidentHeaders, incidents, true, true, tableTitle)


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / Why we need it?

When viewing output of kite alerts --assigned-to=team the user cannot view whom the alert has been assigned to if acknowledged. The alert view table has an additional column 'Assigned-To' which displays the user to whom the alert has been assigned to, if any.

### Which Jira/Github issue(s) does this PR fix?

_Resolves # https://issues.redhat.com/browse/OSD-9102_

### After changes
When a user runs `kite alerts --assigned-to=team` and choose option 3 i.e acknowledged incidents
![Screenshot from 2023-03-12 03-14-46](https://user-images.githubusercontent.com/73513838/224641599-d5075205-ef46-42db-abb6-43dda2612ea8.png)

### Before changes
When a user runs `kite alerts --assigned-to=team` and choose option 3 i.e acknowledged incidents
![Screenshot from 2023-03-12 03-21-18 (1)](https://user-images.githubusercontent.com/73513838/224641825-e6599757-9ef8-4b8d-a232-d45f23d1b1b4.png)
