### PR TITLE
OSD-15583: Removed Resolved Alerts/Incidents View from kite

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -47,7 +47,6 @@ const (
 	// PagerDuty Incident Statuses
 	StatusTriggered    = "triggered"
 	StatusAcknowledged = "acknowledged"
-	StatusResolved     = "resolved"
 	StatusHigh         = "high"
 	StatusLow          = "low"
 

--- a/pkg/pdcli/alerts/handlers.go
+++ b/pkg/pdcli/alerts/handlers.go
@@ -33,7 +33,6 @@ type Alert struct {
 
 var (
 	TrigerredAlerts []Alert
-	ResolvedAlerts  []Alert
 )
 
 // GetIncidents returns a slice of pagerduty incidents.
@@ -102,18 +101,7 @@ func GetIncidentAlerts(c client.PagerDutyClient, incident pdApi.Incident) ([]Ale
 			tempAlertObj.Severity = alert.Severity
 		}
 
-		switch status {
-
-		case constants.StatusResolved:
-			err = tempAlertObj.ParseAlertData(c, &alert)
-
-			if err != nil {
-				return nil, err
-			}
-
-			ResolvedAlerts = append(ResolvedAlerts, tempAlertObj)
-
-		case constants.StatusTriggered:
+		if status == constants.StatusTriggered {
 			err = tempAlertObj.ParseAlertData(c, &alert)
 
 			if err != nil {

--- a/pkg/ui/constants.go
+++ b/pkg/ui/constants.go
@@ -9,7 +9,6 @@ const (
 
 	// Table Titles
 	AlertsTableTitle          = "[ ALERTS ]"
-	ResolvedAlertsTableTitle  = "[ RESOLVED ALERTS ]"
 	TrigerredAlertsTableTitle = "[ TRIGERRED ALERTS ]"
 	HighAlertsTableTitle      = "[ TRIGERRED ALERTS - HIGH ]"
 	LowAlertsTableTitle       = "[ TRIGERRED ALERTS - LOW ]"
@@ -23,7 +22,6 @@ const (
 	// Page Titles
 	AlertsPageTitle          = "Alerts"
 	AlertDataPageTitle       = "Metadata"
-	ResolvedAlertsPageTitle  = "Resolved"
 	TrigerredAlertsPageTitle = "Trigerred"
 	HighAlertsPageTitle      = "High Alerts"
 	LowAlertsPageTitle       = "Low Alerts"
@@ -36,8 +34,8 @@ const (
 	// Footer
 	FooterText                = "[Q] Quit | [Esc] Go Back"
 	FooterTextStatus          = "[H] High Alerts | [L] Low Alerts\n"
-	FooterTextAlerts          = "[R] Refresh Alerts | [1] Resolved Alerts | [2] Trigerred Alerts | [3] Acknowledged Incidents | [4] Trigerred Incidents\n" + FooterText
-	FooterTextTrigerredAlerts = "[1] Resolved Alerts | [2] Trigerred Alerts | [3] Acknowledged Incidents | [4] Trigerred Incidents\n" + FooterTextStatus + FooterText
+	FooterTextAlerts          = "[R] Refresh Alerts | [1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterText
+	FooterTextTrigerredAlerts = "[1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterTextStatus + FooterText
 	FooterTextIncidents       = "[ENTER] Select Incident  | [CTRL+A] Acknowledge Incidents\n" + FooterText
 	FooterTextOncall          = "[N] Your Next Oncall Schedule | [A] All Teams Oncall\n" + FooterText
 

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -59,16 +59,11 @@ func (tui *TUI) setupAlertsPageInput() {
 		tui.Pages.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 
 			if event.Rune() == '1' {
-				utils.InfoLogger.Print("Switching to resolved alerts view")
-				tui.InitAlertsUI(pdcli.ResolvedAlerts, ResolvedAlertsTableTitle, ResolvedAlertsPageTitle)
-			}
-
-			if event.Rune() == '2' {
 				utils.InfoLogger.Print("Switching to trigerred alerts view")
 				tui.InitAlertsUI(pdcli.TrigerredAlerts, TrigerredAlertsTableTitle, TrigerredAlertsPageTitle)
 			}
 
-			if event.Rune() == '3' {
+			if event.Rune() == '2' {
 				utils.InfoLogger.Print("Switching to acknowledged incidents view")
 				tui.SeedAckIncidentsUI()
 
@@ -79,7 +74,7 @@ func (tui *TUI) setupAlertsPageInput() {
 				tui.Pages.SwitchToPage(AckIncidentsPageTitle)
 			}
 
-			if event.Rune() == '4' {
+			if event.Rune() == '3' {
 				utils.InfoLogger.Print("Switching to incidents view")
 				tui.SeedIncidentsUI()
 

--- a/pkg/ui/seeders.go
+++ b/pkg/ui/seeders.go
@@ -98,9 +98,8 @@ func (tui *TUI) SeedAlertsUI() {
 	var incidentAlerts []pdcli.Alert
 	var alerts []pdcli.Alert
 
-	// Refresh triggered and resolved alerts
+	// Refresh triggered alerts
 	pdcli.TrigerredAlerts = []pdcli.Alert{}
-	pdcli.ResolvedAlerts = []pdcli.Alert{}
 
 	if tui.AssignedTo == tui.Username {
 		utils.InfoLogger.Printf("Incidents status set to: %s", constants.StatusAcknowledged)


### PR DESCRIPTION
### What type of PR is this?

_cleanup_

### What this PR does / Why we need it?
Before the PR, the kite alerts looked like :
![image](https://user-images.githubusercontent.com/56730201/226294082-582ab8c9-c04e-4dc8-a4da-d649d0868a5e.png)


This PR changes the following:
- removes the resolved alerts view from kite as it is not required for the SREs
- The page numbers are updated for kite alerts view. 

Updated view:
![image](https://user-images.githubusercontent.com/56730201/226293979-40566a82-3513-4afe-adb2-b18ace8dc72f.png)



### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-15583](https://issues.redhat.com//browse/OSD-15583): Deprecate the resolved incidents/alerts view

### Special notes for your reviewer
-- NA --

### Pre-checks (if applicable)

- [X] Ran unit tests locally against the changes
- [X] Included documentation changes with PR
