### PR TITLE
OSD-15472 : Do not list low alerts

### DIFF
--- a/pkg/ui/constants.go
+++ b/pkg/ui/constants.go
@@ -33,9 +33,8 @@ const (
 
 	// Footer
 	FooterText                = "[Q] Quit | [Esc] Go Back"
-	FooterTextStatus          = "[H] High Alerts | [L] Low Alerts\n"
 	FooterTextAlerts          = "[R] Refresh Alerts | [1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterText
-	FooterTextTrigerredAlerts = "[1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterTextStatus + FooterText
+	FooterTextTrigerredAlerts = "[1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterText
 	FooterTextIncidents       = "[ENTER] Select Incident  | [CTRL+A] Acknowledge Incidents\n" + FooterText
 	FooterTextOncall          = "[N] Your Next Oncall Schedule | [A] All Teams Oncall\n" + FooterText
 

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -85,19 +85,6 @@ func (tui *TUI) setupAlertsPageInput() {
 				tui.Pages.SwitchToPage(IncidentsPageTitle)
 			}
 
-			// Filter by status
-			if title, _ := tui.Pages.GetFrontPage(); title == TrigerredAlertsPageTitle {
-				if event.Rune() == 'H' || event.Rune() == 'h' {
-					tui.SeedHighAlertsUI()
-					tui.Pages.SwitchToPage(HighAlertsPageTitle)
-				}
-
-				if event.Rune() == 'L' || event.Rune() == 'l' {
-					tui.SeedHLowAlertsUI()
-					tui.Pages.SwitchToPage(LowAlertsPageTitle)
-				}
-			}
-
 			// Alerts refresh
 			if event.Rune() == 'r' || event.Rune() == 'R' {
 				utils.InfoLogger.Print("Refreshing alerts...")

--- a/pkg/ui/seeders.go
+++ b/pkg/ui/seeders.go
@@ -6,36 +6,6 @@ import (
 	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
 )
 
-// SeedHighAlertsUI fetches trigerred alerts with status high and initializes a TUI table/page component.
-func (tui *TUI) SeedHighAlertsUI() {
-	var triggeredHigh []pdcli.Alert
-
-	utils.InfoLogger.Print("Fetching high alerts")
-
-	for _, alert := range pdcli.TrigerredAlerts {
-		if alert.Severity == constants.StatusHigh {
-			triggeredHigh = append(triggeredHigh, alert)
-		}
-	}
-
-	tui.InitAlertsUI(triggeredHigh, HighAlertsTableTitle, HighAlertsPageTitle)
-}
-
-// SeedHLowAlertsUI fetches trigerred alerts with status low and initializes a TUI table/page component.
-func (tui *TUI) SeedHLowAlertsUI() {
-	var triggeredLow []pdcli.Alert
-
-	utils.InfoLogger.Print("Fetching low alerts")
-
-	for _, alert := range pdcli.TrigerredAlerts {
-		if alert.Severity == constants.StatusLow {
-			triggeredLow = append(triggeredLow, alert)
-		}
-	}
-
-	tui.InitAlertsUI(triggeredLow, LowAlertsTableTitle, LowAlertsPageTitle)
-}
-
 // SeedAckIncidentsUI fetches acknlowedged incidents and initializes a TUI table/page component.
 func (tui *TUI) SeedAckIncidentsUI() {
 	var ackIncidents [][]string


### PR DESCRIPTION
### What type of PR is this?

_cleanup_

### What this PR does / Why we need it?

Currently, kite fetches alerts of both High (critical) and Low (warning) severity. With service orchestration in place, SRE-P is no longer paged by low alerts. So we will remove the option for high as well low alerts.

#### Before the PR
![Screenshot from 2023-03-21 10-24-42](https://user-images.githubusercontent.com/73513838/226524575-edf0f425-e399-4e77-a6cd-27d9a05b9076.png) 
![Screenshot from 2023-03-21 10-25-26 (1)](https://user-images.githubusercontent.com/73513838/226525073-7bd7a263-1ecf-4683-a15d-dd90db959a9e.png)
#### After the PR
![Screenshot from 2023-03-21 10-22-26](https://user-images.githubusercontent.com/73513838/226524798-ec238322-31c8-4c0e-9e80-5f0e274d0e70.png)

### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-15472](https://issues.redhat.com/browse/OSD-15472)_

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [x] Included documentation changes with PR
