### PR TITLE
OSD-9098: Fixed Footer for Next OnCall Schedule and All Team Oncall Pages

### DIFF
--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -187,6 +187,7 @@ func (tui *TUI) setupOncallPageInput() {
 				if event.Rune() == 'N' || event.Rune() == 'n' {
 					utils.InfoLogger.Print("Viewing user next on-call schedule")
 					tui.Pages.SwitchToPage(NextOncallPageTitle)
+					tui.Footer.SetText(FooterText)
 
 					if len(tui.AckIncidents) == 0 {
 						utils.InfoLogger.Print("You are not scheduled for any oncall duties for the next 3 months. Cheer up!")
@@ -198,6 +199,7 @@ func (tui *TUI) setupOncallPageInput() {
 				if event.Rune() == 'A' || event.Rune() == 'a' {
 					utils.InfoLogger.Print("Switching to all team on-call view")
 					tui.Pages.SwitchToPage(AllTeamsOncallPageTitle)
+					tui.Footer.SetText(FooterText)
 				}
 			}
 


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What this PR does / Why we need it?
The PR fixes the Footer for Next OnCall Schedule and All Team Oncall Pages as navigation between the pages was not directly possible but the footer was showing inputs as a navigation

**Before the Changes**

![image](https://user-images.githubusercontent.com/56730201/226792433-20ae24a1-4099-41f1-bd91-3aea08c77496.png)

**After the Changes:**

![image](https://user-images.githubusercontent.com/56730201/226793053-b6690d8b-c34a-4bb8-95e2-2c0bf84be60e.png)

### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-9098](https://issues.redhat.com//browse/OSD-9098)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [x] Included documentation changes with PR
