### PR TITLE
Show only a single view for trigerred incidents

### DIFF
--- a/pkg/ui/constants.go
+++ b/pkg/ui/constants.go
@@ -22,6 +22,7 @@ const (
 	// Page Titles
 	AlertsPageTitle          = "Alerts"
 	AlertDataPageTitle       = "Metadata"
+	AlertMetadata            = "AlertData"
 	TrigerredAlertsPageTitle = "Trigerred"
 	HighAlertsPageTitle      = "High Alerts"
 	LowAlertsPageTitle       = "Low Alerts"
@@ -34,8 +35,8 @@ const (
 	// Footer
 	FooterText                = "[Q] Quit | [Esc] Go Back"
 	FooterTextStatus          = "[H] High Alerts | [L] Low Alerts\n"
-	FooterTextAlerts          = "[R] Refresh Alerts | [1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterText
-	FooterTextTrigerredAlerts = "[1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterTextStatus + FooterText
+	FooterTextAlerts          = "[R] Refresh Alerts | [1] Acknowledged Incidents | [2] Trigerred Incidents\n" + FooterText
+	FooterTextTrigerredAlerts = "[1] Acknowledged Incidents | [2] Trigerred Incidents\n" + FooterTextStatus + FooterText
 	FooterTextIncidents       = "[ENTER] Select Incident  | [CTRL+A] Acknowledge Incidents\n" + FooterText
 	FooterTextOncall          = "[N] Your Next Oncall Schedule | [A] All Teams Oncall\n" + FooterText
 

--- a/pkg/ui/events.go
+++ b/pkg/ui/events.go
@@ -3,7 +3,8 @@ package ui
 import (
 	"fmt"
 
-	"github.com/gdamore/tcell/v2"
+	pdApi "github.com/PagerDuty/go-pagerduty"
+	"github.com/openshift/pagerduty-short-circuiter/pkg/client"
 	pdcli "github.com/openshift/pagerduty-short-circuiter/pkg/pdcli/alerts"
 	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
 )
@@ -43,17 +44,40 @@ func (tui *TUI) SetIncidentsTableEvents() {
 	tui.SelectedIncidents = make(map[string]string)
 	tui.IncidentsTable.SetSelectedFunc(func(row, column int) {
 
+		var incident pdApi.Incident
+		client, _ := client.NewClient().Connect()
 		incidentID := tui.IncidentsTable.GetCell(row, 0).Text
+		incident.Id = incidentID
+		var clusterName string
+		var alertData string
 
-		if _, ok := tui.SelectedIncidents[incidentID]; !ok || tui.SelectedIncidents[incidentID] == "" {
-			tui.IncidentsTable.GetCell(row, 0).SetTextColor(tcell.ColorLimeGreen)
-			tui.SelectedIncidents[incidentID] = incidentID
-			utils.InfoLogger.Printf("Selected incident: %s", incidentID)
-		} else {
-			tui.IncidentsTable.GetCell(row, 0).SetTextColor(tcell.ColorWhite)
-			tui.SelectedIncidents[incidentID] = ""
-			utils.InfoLogger.Printf("Deselected incident: %s", incidentID)
+		alerts, _ := pdcli.GetIncidentAlerts(client, incident)
+		Alert := alerts[0]
+
+		for _, alert := range alerts {
+			if incidentID == alert.IncidentID {
+				alertData = pdcli.ParseAlertMetaData(alert)
+				clusterName = alert.ClusterName
+				tui.ClusterID = alert.ClusterID
+				break
+			}
 		}
+
+		if len(alerts) == 1 {
+			alertData = pdcli.ParseAlertMetaData(Alert)
+			tui.AlertMetadata.SetText(alertData)
+			tui.Pages.AddAndSwitchToPage(AlertMetadata, tui.AlertMetadata, true)
+
+		} else {
+			tui.SetAlertsTableEvents(alerts)
+			tui.InitAlertsUI(alerts, AlertMetadata, AlertMetadata)
+
+		}
+		// Do not prompt for cluster login if there's no cluster ID associated with the alert (v3 clusters)
+		if tui.ClusterID != "N/A" && tui.ClusterID != "" && alertData != "" {
+			tui.SecondaryWindow.SetText(fmt.Sprintf("Press 'Y' to log into the cluster: %s", clusterName)).SetTextColor(PromptTextColor)
+		}
+
 	})
 }
 
@@ -88,6 +112,7 @@ func (tui *TUI) ackowledgeSelectedIncidents() {
 	tui.AckIncidents = []string{}
 
 	// Refresh Page
+
 	tui.SetIncidentsTableEvents()
 	tui.Pages.SwitchToPage(IncidentsPageTitle)
 }

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"github.com/gdamore/tcell/v2"
 
-	pdcli "github.com/openshift/pagerduty-short-circuiter/pkg/pdcli/alerts"
 	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
 )
 
@@ -20,22 +19,19 @@ func (tui *TUI) initKeyboard() {
 				// If the user is viewing the alert metadata
 				if page == AlertDataPageTitle {
 					tui.Pages.SwitchToPage(tui.FrontPage)
-				} else if page == HighAlertsPageTitle || page == LowAlertsPageTitle {
-					tui.Pages.SwitchToPage(TrigerredAlertsPageTitle)
-					tui.Footer.SetText(FooterTextTrigerredAlerts)
+				} else if page == AlertMetadata {
+					tui.Pages.SwitchToPage(IncidentsPageTitle)
 				} else {
 					tui.InitAlertsUI(tui.Alerts, AlertsTableTitle, AlertsPageTitle)
 					tui.Pages.SwitchToPage(AlertsPageTitle)
 					tui.Footer.SetText(FooterTextAlerts)
 				}
 			}
-
 			// Check if oncall command is executed
 			if tui.Pages.HasPage(OncallPageTitle) {
 				tui.Pages.SwitchToPage(OncallPageTitle)
 				tui.Footer.SetText(FooterTextOncall)
 			}
-
 			return nil
 		}
 
@@ -59,11 +55,6 @@ func (tui *TUI) setupAlertsPageInput() {
 		tui.Pages.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 
 			if event.Rune() == '1' {
-				utils.InfoLogger.Print("Switching to trigerred alerts view")
-				tui.InitAlertsUI(pdcli.TrigerredAlerts, TrigerredAlertsTableTitle, TrigerredAlertsPageTitle)
-			}
-
-			if event.Rune() == '2' {
 				utils.InfoLogger.Print("Switching to acknowledged incidents view")
 				tui.SeedAckIncidentsUI()
 
@@ -74,7 +65,7 @@ func (tui *TUI) setupAlertsPageInput() {
 				tui.Pages.SwitchToPage(AckIncidentsPageTitle)
 			}
 
-			if event.Rune() == '3' {
+			if event.Rune() == '2' {
 				utils.InfoLogger.Print("Switching to incidents view")
 				tui.SeedIncidentsUI()
 
@@ -125,7 +116,6 @@ func (tui *TUI) setupIncidentsPageInput() {
 					tui.ackowledgeSelectedIncidents()
 				}
 			}
-
 			return event
 		})
 	}


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / Why we need it?

Initially there was two views for listing triggered incidents; one view lists the incidents and the other lists the alerts,which was not ideal

This PR changes the following

- Removes the triggered alerts view from kite
- Upon clicking on the triggered incident, kite list alerts related to that incident

Updated View
![Screenshot from 2023-03-22 17-38-12](https://user-images.githubusercontent.com/56041032/226904316-a9fd25f6-ab62-4dd6-b14f-f9fb921e1c46.png)


![Screenshot from 2023-03-22 17-38-17](https://user-images.githubusercontent.com/56041032/226904497-63080753-9c34-4272-9fc6-f114b5210457.png)



### Which Jira/Github issue(s) does this PR fix?

_Resolves [[OSD-15584](https://issues.redhat.com/browse/OSD-15584)] : Show only a single view for trigerred incidents

### Special notes for your reviewer

NA

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [x] Included documentation changes with PR
