### PR TITLE
OSD-15584: Show only a single view for trigerred incidents

### DIFF
--- a/pkg/ui/constants.go
+++ b/pkg/ui/constants.go
@@ -22,6 +22,7 @@ const (
 	// Page Titles
 	AlertsPageTitle          = "Alerts"
 	AlertDataPageTitle       = "Metadata"
+	AlertMetadata            = "AlertData"
 	TrigerredAlertsPageTitle = "Trigerred"
 	HighAlertsPageTitle      = "High Alerts"
 	LowAlertsPageTitle       = "Low Alerts"
@@ -32,10 +33,10 @@ const (
 	AllTeamsOncallPageTitle  = "All Teams Oncall"
 	ServiceLogsPageTitle     = "Service Logs"
 
-	// Footer
+	//Footer
 	FooterText                = "[Esc] Go Back"
-	FooterTextAlerts          = "[R] Refresh Alerts | [1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterText
-	FooterTextTrigerredAlerts = "[1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterText
+	FooterTextAlerts          = "[R] Refresh Alerts | [1] Acknowledged Incidents | [2] Trigerred Incidents\n" + FooterText
+	FooterTextTrigerredAlerts = "[1] Acknowledged Incidents | [2] Trigerred Incidents\n" + FooterText
 	FooterTextIncidents       = "[ENTER] Select Incident | [CTRL+A] Acknowledge Incidents\n" + FooterText
 	FooterTextOncall          = "[N] Your Next Oncall Schedule | [A] All Teams Oncall | [<-] Previous Layer Oncall | [->] Next Layer Oncall \n" + FooterText
 	TerminalFooterText        = "[CTRL + N] Next Slide | [CTRL + P] Previous Slide | [CTRL + A] Add Slide | [CTRL + E] Exit Slide | [CTRL + B] + [Num] Change to Slide with [Num]  | [CTRL + Q] Quit "

--- a/pkg/ui/events.go
+++ b/pkg/ui/events.go
@@ -3,7 +3,8 @@ package ui
 import (
 	"fmt"
 
-	"github.com/gdamore/tcell/v2"
+	pdApi "github.com/PagerDuty/go-pagerduty"
+	"github.com/openshift/pagerduty-short-circuiter/pkg/client"
 	"github.com/openshift/pagerduty-short-circuiter/pkg/ocm"
 	pdcli "github.com/openshift/pagerduty-short-circuiter/pkg/pdcli/alerts"
 	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
@@ -45,17 +46,39 @@ func (tui *TUI) SetIncidentsTableEvents() {
 	tui.SelectedIncidents = make(map[string]string)
 	tui.IncidentsTable.SetSelectedFunc(func(row, column int) {
 
+		var incident pdApi.Incident
+		client, _ := client.NewClient().Connect()
 		incidentID := tui.IncidentsTable.GetCell(row, 0).Text
+		incident.Id = incidentID
+		var clusterName string
+		var alertData string
 
-		if _, ok := tui.SelectedIncidents[incidentID]; !ok || tui.SelectedIncidents[incidentID] == "" {
-			tui.IncidentsTable.GetCell(row, 0).SetTextColor(tcell.ColorLimeGreen)
-			tui.SelectedIncidents[incidentID] = incidentID
-			utils.InfoLogger.Printf("Selected incident: %s", incidentID)
-		} else {
-			tui.IncidentsTable.GetCell(row, 0).SetTextColor(tcell.ColorWhite)
-			tui.SelectedIncidents[incidentID] = ""
-			utils.InfoLogger.Printf("Deselected incident: %s", incidentID)
+		alerts, _ := pdcli.GetIncidentAlerts(client, incident)
+		Alert := alerts[0]
+
+		for _, alert := range alerts {
+			if incidentID == alert.IncidentID {
+				alertData = pdcli.ParseAlertMetaData(alert)
+				clusterName = alert.ClusterName
+				tui.ClusterID = alert.ClusterID
+				break
+			}
 		}
+		if len(alerts) == 1 {
+			alertData = pdcli.ParseAlertMetaData(Alert)
+			tui.AlertMetadata.SetText(alertData)
+			tui.Pages.AddAndSwitchToPage(AlertMetadata, tui.AlertMetadata, true)
+
+		} else {
+			tui.SetAlertsTableEvents(alerts)
+			tui.InitAlertsUI(alerts, AlertMetadata, AlertMetadata)
+
+		}
+		// Do not prompt for cluster login if there's no cluster ID associated with the alert (v3 clusters)
+		if tui.ClusterID != "N/A" && tui.ClusterID != "" && alertData != "" {
+			tui.SecondaryWindow.SetText(fmt.Sprintf("Press 'Y' to log into the cluster: %s", clusterName)).SetTextColor(PromptTextColor)
+		}
+
 	})
 }
 
@@ -90,6 +113,7 @@ func (tui *TUI) ackowledgeSelectedIncidents() {
 	tui.AckIncidents = []string{}
 
 	// Refresh Page
+
 	tui.SetIncidentsTableEvents()
 	tui.Pages.SwitchToPage(IncidentsPageTitle)
 }

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gdamore/tcell/v2"
 
 	"github.com/openshift/pagerduty-short-circuiter/pkg/constants"
-	pdcli "github.com/openshift/pagerduty-short-circuiter/pkg/pdcli/alerts"
 	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
 )
 
@@ -43,19 +42,20 @@ func (tui *TUI) initKeyboard() {
 				case ServiceLogsPageTitle:
 					tui.Pages.SwitchToPage(AlertDataPageTitle)
 					tui.InitAlertDataSecondaryView()
+
+				case AlertMetadata:
+					tui.Pages.SwitchToPage(IncidentsPageTitle)
 				default:
 					tui.InitAlertsUI(tui.Alerts, AlertsTableTitle, AlertsPageTitle)
 					tui.Pages.SwitchToPage(AlertsPageTitle)
 					tui.Footer.SetText(FooterTextAlerts)
 				}
 			}
-
 			// Check if oncall command is executed
 			if title, _ := tui.Pages.GetFrontPage(); strings.Contains(title, "Oncall") {
 				tui.Pages.SwitchToPage(fmt.Sprintf("%s%d", OncallPageTitle, 2))
 				tui.Footer.SetText(FooterTextOncall)
 			}
-
 			return nil
 		}
 		if event.Key() == tcell.KeyLeft && CursorPos > 0 {
@@ -164,11 +164,6 @@ func (tui *TUI) setupAlertsPageInput() {
 		tui.Pages.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 
 			if event.Rune() == '1' {
-				utils.InfoLogger.Print("Switching to trigerred alerts view")
-				tui.InitAlertsUI(pdcli.TrigerredAlerts, TrigerredAlertsTableTitle, TrigerredAlertsPageTitle)
-			}
-
-			if event.Rune() == '2' {
 				utils.InfoLogger.Print("Switching to acknowledged incidents view")
 				tui.SeedAckIncidentsUI()
 
@@ -179,7 +174,7 @@ func (tui *TUI) setupAlertsPageInput() {
 				tui.Pages.SwitchToPage(AckIncidentsPageTitle)
 			}
 
-			if event.Rune() == '3' {
+			if event.Rune() == '2' {
 				utils.InfoLogger.Print("Switching to incidents view")
 				tui.SeedIncidentsUI()
 
@@ -195,7 +190,6 @@ func (tui *TUI) setupAlertsPageInput() {
 				utils.InfoLogger.Print("Refreshing alerts...")
 				tui.SeedAlertsUI()
 			}
-
 			return event
 		})
 	}
@@ -217,7 +211,6 @@ func (tui *TUI) setupIncidentsPageInput() {
 					tui.ackowledgeSelectedIncidents()
 				}
 			}
-
 			return event
 		})
 	}
@@ -262,7 +255,6 @@ func (tui *TUI) setupOncallPageInput() {
 				if event.Rune() == 'N' || event.Rune() == 'n' {
 					utils.InfoLogger.Print("Viewing user next on-call schedule")
 					tui.Pages.SwitchToPage(NextOncallPageTitle)
-					tui.Footer.SetText(FooterText)
 
 					if len(tui.AckIncidents) == 0 {
 						utils.InfoLogger.Print("You are not scheduled for any oncall duties for the next 3 months. Cheer up!")
@@ -274,7 +266,6 @@ func (tui *TUI) setupOncallPageInput() {
 				if event.Rune() == 'A' || event.Rune() == 'a' {
 					utils.InfoLogger.Print("Switching to all team on-call view")
 					tui.Pages.SwitchToPage(AllTeamsOncallPageTitle)
-					tui.Footer.SetText(FooterText)
 				}
 			}
 			if event.Key() == tcell.KeyLeft {

--- a/tests/alerts_test.go
+++ b/tests/alerts_test.go
@@ -222,6 +222,50 @@ var _ = Describe("view alerts", func() {
 		})
 	})
 
+	When("the triggered incidents are fetched", func() {
+		It("gives the alert metadata page for triggered incidents", func() {
+
+			var alertData pdcli.Alert
+
+			alertResponse := &pdApi.ListAlertsResponse{
+				Alerts: []pdApi.IncidentAlert{
+					alert(
+						"incident-id-1",
+						"my-service-id",
+						"alert-name",
+						"cluster-id",
+						"triggered",
+					),
+				},
+			}
+
+			// Set the mock cluster name
+			serviceResponse := &pdApi.Service{
+				Description: "my-cluster-name",
+			}
+
+			expectedAlertData := pdcli.Alert{
+				IncidentID:  "incident-id-1",
+				Name:        "alert-name",
+				ClusterID:   "cluster-id",
+				ClusterName: "my-cluster-name",
+				Status:      "triggered",
+				Console:     "<nil>",
+				Labels:      "<nil>",
+				Sop:         "<nil>",
+			}
+
+			mockClient.EXPECT().GetService("my-service-id", gomock.Any()).Return(serviceResponse, nil).Times(1)
+
+			err := alertData.ParseAlertData(mockClient, &alertResponse.Alerts[0])
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(alertData).To(Equal(expectedAlertData))
+
+		})
+	})
+
 	When("a user acknowledges an incident(s)", func() {
 		It("it changes the incident status to acknowledged and returns the incident(s)", func() {
 


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / Why we need it?
Initially there was two views for listing triggered incidents; one view lists the incidents and the other lists the alerts,which was not ideal

This PR changes the following

- Removes the triggered alerts view from kite
- Upon clicking on the triggered incident, kite list alerts related to that incident

![Screenshot from 2023-03-22 17-38-12](https://user-images.githubusercontent.com/56041032/226925439-fc207bb8-8e91-41fb-8628-9dd9720f536e.png)

![Screenshot from 2023-03-22 17-38-17](https://user-images.githubusercontent.com/56041032/226925482-222925b8-02a1-49c2-8fe3-fea8746385b8.png)


### Which Jira/Github issue(s) does this PR fix?

_Resolves [[OSD-15584](https://issues.redhat.com/browse/OSD-15584)] : Show only a single view for trigerred incidents

### Special notes for your reviewer

NA
### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [x] Included documentation changes with PR
