### PR TITLE
OSD-15769 : new shortcut for ocm-container has been added

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -21,6 +21,8 @@ const (
 
 	APIKeyURL       = "https://support.pagerduty.com/docs/generating-api-keys#generating-a-personal-rest-api-key"
 	OcmContainerURL = "https://github.com/openshift/ocm-container"
+	OcmContainer    = "ocm-container"
+	Bash            = "bash"
 
 	// Regex
 	APIKeyRegex     = "^[a-z|A-Z0-9+_-]{20}$"

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -1,10 +1,11 @@
 package ui
 
 import (
+	"os/exec"
 	"strconv"
 
 	"github.com/gdamore/tcell/v2"
-
+	"github.com/openshift/pagerduty-short-circuiter/pkg/constants"
 	pdcli "github.com/openshift/pagerduty-short-circuiter/pkg/pdcli/alerts"
 	"github.com/openshift/pagerduty-short-circuiter/pkg/utils"
 )
@@ -50,7 +51,16 @@ func (tui *TUI) initKeyboard() {
 			return nil
 			// Add a new Slide
 		} else if event.Key() == tcell.KeyCtrlA {
-			AddSlide(tui)
+			AddSlide(tui, "bash")
+			return nil
+			// Add a new Slide - ocm-container
+		} else if event.Key() == tcell.KeyCtrlO {
+			_, err := exec.LookPath("ocm-container")
+			if err != nil {
+				utils.ErrorLogger.Println("ocm-container is not found.\nPlease install it via:", constants.OcmContainerURL)
+			} else {
+				AddSlide(tui, "ocm-container")
+			}
 			return nil
 			// Delete the current active Slide
 		} else if event.Key() == tcell.KeyCtrlE {

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -49,17 +49,17 @@ func (tui *TUI) initKeyboard() {
 		} else if event.Key() == tcell.KeyCtrlP {
 			PreviousSlide(tui)
 			return nil
-			// Add a new Slide
+			// Add a new Slide - bash
 		} else if event.Key() == tcell.KeyCtrlA {
-			AddSlide(tui, "bash")
+			AddSlide(tui, constants.Bash)
 			return nil
 			// Add a new Slide - ocm-container
 		} else if event.Key() == tcell.KeyCtrlO {
-			_, err := exec.LookPath("ocm-container")
+			_, err := exec.LookPath(constants.OcmContainer)
 			if err != nil {
 				utils.ErrorLogger.Println("ocm-container is not found.\nPlease install it via:", constants.OcmContainerURL)
 			} else {
-				AddSlide(tui, "ocm-container")
+				AddSlide(tui, constants.OcmContainer)
 			}
 			return nil
 			// Delete the current active Slide

--- a/pkg/ui/tab.go
+++ b/pkg/ui/tab.go
@@ -100,8 +100,13 @@ func RemoveSlide(s int, tui *TUI) {
 }
 
 // Adds a slide to the end of currently present slides
-func AddSlide(tui *TUI) {
-	tabSlide := *NewTab("bash", os.Getenv("SHELL"), tui)
+func AddSlide(tui *TUI, name string) {
+	var tabSlide TerminalTab
+	if name == "bash" {
+		tabSlide = *NewTab(name, os.Getenv("SHELL"), tui)
+	} else if name == "ocm-container" {
+		tabSlide = *NewTab(name, "ocm-container", tui)
+	}
 	tui.TerminalTabs = append(tui.TerminalTabs, tabSlide)
 	tui.TerminalPages.AddPage(strconv.Itoa(tabSlide.index), tabSlide.primitive, true, tabSlide.index == 0)
 	fmt.Fprintf(tui.TerminalPageBar, `["%d"]%s[white][""]  `, tabSlide.index, fmt.Sprintf("%d %s", tabSlide.index+1, tabSlide.title))

--- a/pkg/ui/tab.go
+++ b/pkg/ui/tab.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"git.sr.ht/~rockorager/tterm"
+	"github.com/openshift/pagerduty-short-circuiter/pkg/constants"
 	"github.com/rivo/tview"
 )
 
@@ -102,9 +103,9 @@ func RemoveSlide(s int, tui *TUI) {
 // Adds a slide to the end of currently present slides
 func AddSlide(tui *TUI, name string) {
 	var tabSlide TerminalTab
-	if name == "bash" {
+	if name == constants.Bash {
 		tabSlide = *NewTab(name, os.Getenv("SHELL"), tui)
-	} else if name == "ocm-container" {
+	} else if name == constants.OcmContainer {
 		tabSlide = *NewTab(name, "ocm-container", tui)
 	}
 	tui.TerminalTabs = append(tui.TerminalTabs, tabSlide)

--- a/pkg/utils/emulator.go
+++ b/pkg/utils/emulator.go
@@ -55,7 +55,7 @@ func InitTerminalEmulator() string {
 // ClusterLoginShell spawns an instance of ocm-container in the same shell.
 func ClusterLoginShell(clusterID string) *exec.Cmd {
 	// Check if ocm-container is installed locally
-	ocmContainer, err := exec.LookPath("ocm-container")
+	ocmContainer, err := exec.LookPath(constants.OcmContainer)
 
 	if err != nil {
 		fmt.Println("ocm-container is not found.\nPlease install it via:", constants.OcmContainerURL)
@@ -75,7 +75,7 @@ func ClusterLoginEmulator(clusterID string) error {
 	var cmd *exec.Cmd
 
 	// Check if ocm-container is installed locally
-	ocmContainer, err := exec.LookPath("ocm-container")
+	ocmContainer, err := exec.LookPath(constants.OcmContainer)
 
 	if err != nil {
 		return errors.New("ocm-container is not found.\nPlease install it via: " + constants.OcmContainerURL)


### PR DESCRIPTION
### What type of PR is this?

_feature_

### What this PR does / Why we need it?
When we press CTRL + O it adds a new tab called ocm-container and when we press CTRL + A it adds a new tab called bash.
#### After this PR
#### when we press CTRL + O
![Screenshot from 2023-04-03 15-48-41](https://user-images.githubusercontent.com/73513838/229484074-082e802e-a507-4ea0-86c7-67ac8c345781.png)
#### when we press CTRL + A
![Screenshot from 2023-04-03 16-00-27](https://user-images.githubusercontent.com/73513838/229484919-3783804e-2c8d-4bec-951d-ee5a47e90ce3.png)

### Which Jira/Github issue(s) does this PR fix?

_Resolves _ #[OSD-15769](https://issues.redhat.com/browse/OSD-15769)

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [ ] Included documentation changes with PR
