### PR TITLE
OSD-15773: Open cluster login from alerts page in new terminal tab

### DIFF
--- a/pkg/ui/events.go
+++ b/pkg/ui/events.go
@@ -12,7 +12,6 @@ import (
 // It handles the program flow when a table selection is made.
 func (tui *TUI) SetAlertsTableEvents(alerts []pdcli.Alert) {
 	tui.Table.SetSelectedFunc(func(row int, column int) {
-		var clusterName string
 		var alertData string
 
 		alertID := tui.Table.GetCell(row, 1).Text
@@ -21,7 +20,7 @@ func (tui *TUI) SetAlertsTableEvents(alerts []pdcli.Alert) {
 			if alertID == alert.AlertID {
 				utils.InfoLogger.Printf("GET: fetching alert metadata for alert ID: %s", alertID)
 				alertData = pdcli.ParseAlertMetaData(alert)
-				clusterName = alert.ClusterName
+				tui.ClusterName = alert.ClusterName
 				tui.ClusterID = alert.ClusterID
 				break
 			}
@@ -32,7 +31,7 @@ func (tui *TUI) SetAlertsTableEvents(alerts []pdcli.Alert) {
 
 		// Do not prompt for cluster login if there's no cluster ID associated with the alert (v3 clusters)
 		if tui.ClusterID != "N/A" && tui.ClusterID != "" && alertData != "" {
-			tui.SecondaryWindow.SetText(fmt.Sprintf("Press 'Y' to log into the cluster: %s", clusterName)).SetTextColor(PromptTextColor)
+			tui.SecondaryWindow.SetText(fmt.Sprintf("Press 'Y' to log into the cluster: %s", tui.ClusterName)).SetTextColor(PromptTextColor)
 		}
 	})
 }

--- a/pkg/ui/input.go
+++ b/pkg/ui/input.go
@@ -168,10 +168,11 @@ func (tui *TUI) setupAlertDetailsPageInput() {
 			if err != nil {
 				errMessage := "ocm-container is not found.\nPlease install it via: " + constants.OcmContainerURL
 				utils.ErrorLogger.Print(errMessage)
+				return nil
 			}
 			// Convert the ClusterID into args for ocm-container command
 			clusterIDArgs := []string{tui.ClusterID}
-			AddNewSlide(tui, tui.ClusterID, ocmContainer, clusterIDArgs, true)
+			AddNewSlide(tui, tui.ClusterName, ocmContainer, clusterIDArgs, true)
 		}
 
 		return event

--- a/pkg/ui/tab.go
+++ b/pkg/ui/tab.go
@@ -109,8 +109,8 @@ func AddNewSlide(tui *TUI, name string, command string, args []string, isCluster
 			}
 		}
 	}
-	tabSlide := *NewTab(name, command, args, tui)
-	tui.TerminalTabs = append(tui.TerminalTabs, tabSlide)
+	tabSlide := NewTab(name, command, args, tui)
+	tui.TerminalTabs = append(tui.TerminalTabs, *tabSlide)
 	tui.TerminalPages.AddPage(strconv.Itoa(tabSlide.index), tabSlide.primitive, true, tabSlide.index == 0)
 	fmt.Fprintf(tui.TerminalPageBar, `["%d"]%s[white][""]  `, tabSlide.index, fmt.Sprintf("%d %s", tabSlide.index+1, tabSlide.title))
 	CurrentActivePage = tabSlide.index

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -41,6 +41,7 @@ type TUI struct {
 	Role              string
 	Columns           string
 	ClusterID         string
+	ClusterName       string
 
 	// Multi-Window Terminals Related
 	TerminalLayout      *tview.Flex


### PR DESCRIPTION
### What type of PR is this?

_Feature_

### What this PR does / Why we need it?
This PR adds the feature to open a cluster login in a new tab alongside kite. When a user presses Y on a alert, it opens up a ocm-container instance in new tab. If the cluster is already present it switches to that cluster tab

### Which Jira/Github issue(s) does this PR fix?

_Resolves #[OSD-15773](https://issues.redhat.com//browse/OSD-15773)_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [X] Ran unit tests locally against the changes
- [ ] Included documentation changes with PR
