### PR TITLE
WIP OSD-15763 : Fix the program crashing error when many slides are removed at once

### DIFF
--- a/pkg/ui/tab.go
+++ b/pkg/ui/tab.go
@@ -39,7 +39,7 @@ func InitKiteTab(tui *TUI, layout *tview.Flex) *TerminalTab {
 func NewTab(name string, command string, tui *TUI) *TerminalTab {
 	TotalPageCount += 1
 	tui.TerminalUIRegionIDs = append(tui.TerminalUIRegionIDs, TotalPageCount)
-	index := len(tui.TerminalTabs)
+	index := tui.TerminalTabs[len(tui.TerminalTabs)-1].index + 1
 	if len(tui.TerminalTabs) == 0 {
 		index = 0
 	}
@@ -62,7 +62,7 @@ func newTabPrimitive(command string) (content tview.Primitive) {
 // Move to the previous slide
 func PreviousSlide(tui *TUI) {
 	CurrentActivePage = (CurrentActivePage - 1 + len(tui.TerminalTabs)) % len(tui.TerminalTabs)
-	tui.TerminalPageBar.Highlight(strconv.Itoa(tui.TerminalUIRegionIDs[CurrentActivePage])).
+	tui.TerminalPageBar.Highlight(strconv.Itoa(tui.TerminalTabs[CurrentActivePage].index)).
 		ScrollToHighlight()
 	tui.TerminalInputBuffer = []rune{}
 }
@@ -70,13 +70,13 @@ func PreviousSlide(tui *TUI) {
 // Move to the next slide
 func NextSlide(tui *TUI) {
 	CurrentActivePage = (CurrentActivePage + 1) % len(tui.TerminalTabs)
-	tui.TerminalPageBar.Highlight(strconv.Itoa(tui.TerminalUIRegionIDs[CurrentActivePage])).
+	tui.TerminalPageBar.Highlight(strconv.Itoa(tui.TerminalTabs[CurrentActivePage].index)).
 		ScrollToHighlight()
 	tui.TerminalInputBuffer = []rune{}
 }
 
-func indexOf(arr []int, ele int) int {
-	for index, item := range arr {
+func indexOf(RegionIDs []int, ele int) int {
+	for index, item := range RegionIDs {
 		if item == ele {
 			return index
 		}
@@ -97,14 +97,15 @@ func RemoveSlide(s int, tui *TUI) {
 	}
 	tui.TerminalPages.RemovePage(strconv.Itoa(s))
 	PreviousSlide(tui)
+	tui.TerminalInputBuffer = []rune{}
 }
 
 // Adds a slide to the end of currently present slides
 func AddSlide(tui *TUI) {
 	tabSlide := *NewTab("bash", os.Getenv("SHELL"), tui)
 	tui.TerminalTabs = append(tui.TerminalTabs, tabSlide)
-	tui.TerminalPages.AddPage(strconv.Itoa(tabSlide.index), tabSlide.primitive, true, tabSlide.index == 0)
-	fmt.Fprintf(tui.TerminalPageBar, `["%d"]%s[white][""]  `, tabSlide.index, fmt.Sprintf("%d %s", tabSlide.index+1, tabSlide.title))
+	tui.TerminalPages.AddPage(strconv.Itoa(tabSlide.index), tabSlide.primitive, true, true)
+	fmt.Fprintf(tui.TerminalPageBar, `["%d"]%s[white][""]  `, tabSlide.index, fmt.Sprintf("%d %s", len(tui.TerminalTabs), tabSlide.title))
 	CurrentActivePage = tabSlide.index
 	tui.TerminalPageBar.Highlight(strconv.Itoa(CurrentActivePage)).
 		ScrollToHighlight()


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What this PR does / Why we need it?
Solves the bug which is occurred when any number of pages can be added or deleted and the app crashes.
Also solves app crashing when exit command & remove slide are executed simultaneously.
### Which Jira/Github issue(s) does this PR fix?

- _Work in progress_ #[OSD-15766](https://issues.redhat.com/browse/OSD-15766)
- _Work in progress_ #[OSD-15763](https://issues.redhat.com/browse/OSD-15763)

### Special notes for your reviewer
For issue [OSD-15763](https://issues.redhat.com/browse/OSD-15763) some bugs are still not resolved :

- After continuous addition and deletion there comes a point where if we try to delete a page it throws an error `slice bound out of range [-1]` even if some pages are present.
- After adding a new page and pressing ctrl + N ideally the cursor should move to the 1st page but it moves to a random page.

### Pre-checks (if applicable)

- [X] Ran unit tests locally against the changes
- [ ] Included documentation changes with PR
