### PR TITLE
Fixed Bug with Tab Switching overriding Alerts Page Commands

### DIFF
--- a/pkg/ui/constants.go
+++ b/pkg/ui/constants.go
@@ -37,14 +37,17 @@ const (
 	FooterTextTrigerredAlerts = "[1] Trigerred Alerts | [2] Acknowledged Incidents | [3] Trigerred Incidents\n" + FooterText
 	FooterTextIncidents       = "[ENTER] Select Incident | [CTRL+A] Acknowledge Incidents\n" + FooterText
 	FooterTextOncall          = "[N] Your Next Oncall Schedule | [A] All Teams Oncall\n" + FooterText
-	TerminalFooterText        = "[CTRL + N] Next Slide | [CTRL + P] Previous Slide | [CTRL + A] Add Slide | [CTRL + E] Exit Slide | [CTRL + O] New Cluster Login | [CTRL + Q] Quit "
+	TerminalFooterText        = "[CTRL + N] Next Slide | [CTRL + P] Previous Slide | [CTRL + A] Add Slide | [CTRL + E] Exit Slide | [CTRL + B] + [Num] Change to Slide with [Num]  | [CTRL + Q] Quit "
+	TerminalFooterEscapeState = "Enter the Slide Number to Switch To : "
 
 	// Colors
-	TableTitleColor = tcell.ColorLightCyan
-	BorderColor     = tcell.ColorLightGray
-	FooterTextColor = tcell.ColorGray
-	InfoTextColor   = tcell.ColorLightSlateGray
-	ErrorTextColor  = tcell.ColorRed
-	PromptTextColor = tcell.ColorLightGreen
-	LoggerTextColor = tcell.ColorGreen
+	TableTitleColor                = tcell.ColorLightCyan
+	BorderColor                    = tcell.ColorLightGray
+	FooterTextColor                = tcell.ColorGray
+	InfoTextColor                  = tcell.ColorLightSlateGray
+	ErrorTextColor                 = tcell.ColorRed
+	PromptTextColor                = tcell.ColorLightGreen
+	LoggerTextColor                = tcell.ColorGreen
+	TerminalFooterTextColor        = tcell.ColorGreen
+	TerminalFooterEscapeStateColor = tcell.ColorDarkGreen
 )

--- a/pkg/ui/tab.go
+++ b/pkg/ui/tab.go
@@ -117,6 +117,18 @@ func AddNewSlide(tui *TUI, name string, command string, args []string, isCluster
 	tui.TerminalInputBuffer = []rune{}
 }
 
+// Navigate to the specified slide
+func SwitchToSlide(slideNum int, tui *TUI) {
+	if slideNum > 0 && slideNum <= len(tui.TerminalTabs) {
+		slideNum = slideNum - 1
+		regionID := tui.TerminalTabs[slideNum].regionID
+		tui.TerminalPageBar.Highlight(strconv.Itoa(regionID)).
+			ScrollToHighlight()
+		CurrentActivePage = slideNum
+	}
+}
+
+// Init the Layout for Terminal Multiplexer
 func InitTerminalMux(tui *TUI, kiteTab *TerminalTab) *tview.Flex {
 	// Initial Slides
 	tui.TerminalTabs = append(tui.TerminalTabs, *kiteTab)

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -163,7 +163,7 @@ func (tui *TUI) Init() {
 		SetBorderPadding(1, 0, 1, 1)
 
 	tui.TerminalFixedFooter.
-		Clear().SetBackgroundColor(tcell.ColorGreen)
+		Clear().SetBackgroundColor(TerminalFooterTextColor)
 
 	tui.AlertMetadata.
 		SetScrollable(true).


### PR DESCRIPTION
### What type of PR is this?

_bug_

### What this PR does / Why we need it?

### Which Jira/Github issue(s) does this PR fix?
This fixes the input issue causing tab switching to override other commands in the alerts page. The tab switching will now work in the order. Press **Ctrl + B** to enter escape state/mode. Press **1 - 9** to switch to that tab. This shortcut is similar to native tmux

_Resolves #_

### Special notes for your reviewer

### Pre-checks (if applicable)

- [x] Ran unit tests locally against the changes
- [x] Included documentation changes with PR
