### PR TITLE
[Bug] Fix login command

### DIFF
--- a/cmd/kite/login/cmd.go
+++ b/cmd/kite/login/cmd.go
@@ -78,22 +78,10 @@ func loginHandler(cmd *cobra.Command, args []string) error {
 		cfg = new(config.Config)
 	}
 
-	// If the key arg is not empty
+	// Set PagerDuty API key from cmd args or ask interactively
 	if loginArgs.apiKey != "" {
-
 		cfg.ApiKey = loginArgs.apiKey
-
-		// Save the key in the config file
-		err = config.Save(cfg)
-
-		if err != nil {
-			return err
-		}
-	}
-
-	// API key is not found in the config file
-	if len(cfg.ApiKey) == 0 {
-
+	} else {
 		// Create a new API key and store it in the config file
 		err = generateNewKey(cfg)
 
@@ -102,22 +90,23 @@ func loginHandler(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// API key is not found in the config file
-	if len(cfg.AccessToken) == 0 {
-
+	// Set Github Access key from cmd args or ask interactively
+	if loginArgs.accessToken != "" {
+		cfg.AccessToken = loginArgs.accessToken
+	} else {
 		// Create a new API key and store it in the config file
 		err = generateNewAccessToken(cfg)
 
 		if err != nil {
 			return err
 		}
+	}
 
-		// Save the key in the config file
-		err = config.Save(cfg)
+	// Save the config
+	err = config.Save(cfg)
 
-		if err != nil {
-			return err
-		}
+	if err != nil {
+		return err
 	}
 
 	// Connect to PagerDuty API client


### PR DESCRIPTION
Fixes the following error:

```
$ kite login --api-key "$PD_TOKEN" --access-token "$GH_TOKEN>"
Usage:
  kite login [flags]

Flags:
      --access-token string   GitHub Personal Access Token generated from https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
                              Use this option to overwrite the existing Access Token.
      --api-key string        Access API key/token generated from https://support.pagerduty.com/docs/generating-api-keys#generating-a-personal-rest-api-key
                              Use this option to overwrite the existing API key.
  -h, --help                  help for login

Error: GET https://api.github.com/repos/openshift/ops-sop: 401 Bad credentials []
```